### PR TITLE
expose DataProcessor

### DIFF
--- a/src/Sparklines.js
+++ b/src/Sparklines.js
@@ -52,4 +52,4 @@ class Sparklines extends React.Component {
     }
 }
 
-export { Sparklines, SparklinesLine, SparklinesBars, SparklinesSpots, SparklinesReferenceLine, SparklinesNormalBand }
+export { Sparklines, SparklinesLine, SparklinesBars, SparklinesSpots, SparklinesReferenceLine, SparklinesNormalBand, DataProcessor }


### PR DESCRIPTION
I'd like to re-use DataProcessor for doing math needed for a hover-indicator. This exposes it.