### PR TITLE
Better SparklineBars

### DIFF
--- a/src/SparklinesBars.js
+++ b/src/SparklinesBars.js
@@ -3,6 +3,8 @@ import React from 'react';
 export default class SparklinesBars extends React.Component {
 
     static propTypes = {
+        points: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
+        height: React.PropTypes.number.isRequired,
         style: React.PropTypes.object
     };
 
@@ -12,7 +14,7 @@ export default class SparklinesBars extends React.Component {
 
     render() {
 
-        const { points, width, height, margin, style } = this.props;
+        const { points, height, style } = this.props;
         const barWidth = points.length >= 2 ? Math.max(0, points[1].x - points[0].x) : 0;
 
         return (
@@ -20,8 +22,10 @@ export default class SparklinesBars extends React.Component {
                 {points.map((p, i) =>
                     <rect
                         key={i}
-                        x={p.x} y={p.y}
-                        width={barWidth} height={Math.max(0, height - p.y)}
+                        x={p.x}
+                        y={p.y}
+                        width={barWidth}
+                        height={Math.max(0, height - p.y)}
                         style={style} />
                 )}
             </g>

--- a/src/SparklinesBars.js
+++ b/src/SparklinesBars.js
@@ -13,7 +13,7 @@ export default class SparklinesBars extends React.Component {
     render() {
 
         const { points, width, height, margin, style } = this.props;
-        const barWidth = points.length >= 2 ? points[1].x - points[0].x : 0;
+        const barWidth = points.length >= 2 ? Math.max(0, points[1].x - points[0].x) : 0;
 
         return (
             <g>
@@ -21,7 +21,7 @@ export default class SparklinesBars extends React.Component {
                     <rect
                         key={i}
                         x={p.x} y={p.y}
-                        width={barWidth} height={height - p.y}
+                        width={barWidth} height={Math.max(0, height - p.y)}
                         style={style} />
                 )}
             </g>

--- a/src/SparklinesBars.js
+++ b/src/SparklinesBars.js
@@ -22,10 +22,10 @@ export default class SparklinesBars extends React.Component {
                 {points.map((p, i) =>
                     <rect
                         key={i}
-                        x={p.x}
-                        y={p.y}
-                        width={barWidth}
-                        height={Math.max(0, height - p.y)}
+                        x={Math.ceil(p.x)}
+                        y={Math.ceil(p.y)}
+                        width={Math.ceil(barWidth)}
+                        height={Math.ceil(Math.max(0, height - p.y))}
                         style={style} />
                 )}
             </g>


### PR DESCRIPTION
1. Fixed #14 
1. Fixed an issue with antialiasing of svg. See screenshots.
1. Better code style, removed unused variables, added used props into propTypes

Before:
![2015-09-24 at 13 06](https://cloud.githubusercontent.com/assets/11071/10072047/e3db329c-62be-11e5-8618-bfecd177682a.png)

After:
![2015-09-24 at 13 05](https://cloud.githubusercontent.com/assets/11071/10072050/ea030906-62be-11e5-84aa-316c5dcfdfee.png)

I think the precision doesn't matter in case of sparklines.
