### PR TITLE
Fix an issue where emptying the data provided to Sparklines would not cause a rerender.

### DIFF
--- a/src/Sparklines.js
+++ b/src/Sparklines.js
@@ -32,6 +32,7 @@ class Sparklines extends React.Component {
         return nextProps.width != this.props.width ||
             nextProps.height != this.props.height ||
             nextProps.margin != this.props.margin ||
+            nextProps.data.length != this.props.data.length ||
             nextProps.data.some((d, i) => d !== this.props.data[i]);
     }
 


### PR DESCRIPTION
I'm not sure how this interacts with `limit`, but judging by the docs I think it should be fine.

Specifically, I discovered this when I got some empty data `[]` and passed it to a `Sparklines` that already had non-empty data `[...]`.