### PR TITLE
Remove duplicate `externals` key from webpack config that was breaking `root`-style packaging.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = {
             amd: 'react'
         }
     },
-    externals: { react: 'react' },
     module: {
         loaders: [{
             test: /\.jsx?$/,


### PR DESCRIPTION
This was my fault from #23, I made a mistake when extracting the change from some other code.

Thanks for merging/releasing so fast though!