### PR TITLE
Remove dependency on mocha-babel

### DIFF
--- a/__tests__/Sparklines.js
+++ b/__tests__/Sparklines.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import TestUtils from 'react/lib/ReactTestUtils';
 import { expect } from 'chai';
 import { Sparklines } from '../src/Sparklines';
@@ -11,12 +12,12 @@ describe('Sparklines', () => {
 
     it('should render nothing without data', () => {
         const sparklines = TestUtils.renderIntoDocument(<Sparklines />);
-        expect(React.findDOMNode(sparklines)).to.be.null;
+        expect(ReactDOM.findDOMNode(sparklines)).to.be.null;
     });
 
     it('is rendered as svg', () => {
         const sparklines = TestUtils.renderIntoDocument(<Sparklines data={[1]}/>);
-        expect(React.findDOMNode(sparklines).tagName).to.eq('svg');
+        expect(ReactDOM.findDOMNode(sparklines).tagName).to.eq('svg');
     });
 
 });

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "start": "cd demo && webpack-dev-server --progress",
-    "test": "mocha --compilers js:mocha-babel __tests__",
-    "test:watch": "mocha --compilers js:mocha-babel --watch __tests__",
+    "test": "mocha --compilers js:babel/register __tests__",
+    "test:watch": "mocha --compilers js:babel/register --watch __tests__",
     "compile": "webpack",
     "prepublish": "npm run compile"
   },
@@ -40,7 +40,8 @@
     "chai": "^3.3.0",
     "jsdom": "^3.1.2",
     "mocha": "^2.3.3",
-    "mocha-babel": "^3.0.0",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
     "webpack": "^1.10.0",
     "webpack-dev-server": "^1.10.1"
   },


### PR DESCRIPTION
Looks like mocha-babel has been removed from npm, and babel includes a hook for mocha anyway.