### PR TITLE
WIP: Support gaps in data (null, NaN, etc)

### DIFF
--- a/__tests__/DataProcessor.js
+++ b/__tests__/DataProcessor.js
@@ -104,4 +104,43 @@ describe('DataProcessor', () => {
             expect(DataProcessor.median(data)).to.eq(3668.810244)
         })
     });
+
+    describe('isGapValue', () => {
+        it('finite numbers are not gaps', () => {
+            expect(DataProcessor.isGapValue(0)).to.eq(false);
+            expect(DataProcessor.isGapValue(1.5)).to.eq(false);
+        });
+
+        it('anything else is a gap', () => {
+            expect(DataProcessor.isGapValue(Infinity)).to.eq(true);
+            expect(DataProcessor.isGapValue(-Infinity)).to.eq(true);
+            expect(DataProcessor.isGapValue(NaN)).to.eq(true);
+            expect(DataProcessor.isGapValue('0')).to.eq(true);
+            expect(DataProcessor.isGapValue('1.5')).to.eq(true);
+            expect(DataProcessor.isGapValue({})).to.eq(true);
+            expect(DataProcessor.isGapValue(null)).to.eq(true);
+            expect(DataProcessor.isGapValue(undefined)).to.eq(true);
+            expect(DataProcessor.isGapValue([])).to.eq(true);
+        });
+    });
+
+    describe('pointsToSegments', () => {
+        it('without gap', () => {
+            expect(DataProcessor.pointsToSegments([{x: 0, y: 0}])).to.eql([{isGap: false, points: [{x: 0, y: 0}]}]);
+            expect(DataProcessor.pointsToSegments([{x: 0, y: 0}, {x: 1, y: 1}, {x: 2, y: 1}])).to.eql([{isGap: false, points: [{x: 0, y: 0}, {x: 1, y: 1}, {x: 2, y: 1}]}]);
+        });
+        it('only gap', () => {
+            expect(DataProcessor.pointsToSegments([{x: 0, y: null}])).to.eql([{isGap: true, points: [{x: 0, y: null}]}]);
+            expect(DataProcessor.pointsToSegments([{x: 0, y: null}, {x: 1, y: null}, {x: 2, y: null}])).to.eql([{isGap: true, points: [{x: 0, y: null}, {x: 1, y: null}, {x: 2, y: null}]}]);
+        });
+        it('gap-nongap', () => {
+            expect(DataProcessor.pointsToSegments([{x: 0, y: null}, {x: 1, y: 2}, {x: 2, y: 3}])).to.eql([{isGap: true, points: [{x: 0, y: null}]}, {isGap: false, points: [{x: 1, y: 2}, {x: 2, y: 3}]}]);
+        });
+        it('nongap-gap', () => {
+            expect(DataProcessor.pointsToSegments([{x: 0, y: 1}, {x: 1, y: null}, {x: 2, y: null}])).to.eql([{isGap: false, points: [{x: 0, y: 1}]}, {isGap: true, points: [{x: 1, y: null}, {x: 2, y: null}]}]);
+        });
+        it('gap-nongap-gap', () => {
+            expect(DataProcessor.pointsToSegments([{x: 0, y: null}, {x: 1, y: 2}, {x: 2, y: null}])).to.eql([{isGap: true, points: [{x: 0, y: null}]}, {isGap: false, points: [{x: 1, y: 2}]}, {isGap: true, points: [{x: 2, y: null}]}]);
+        });
+    });
 });

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -29,6 +29,7 @@ function randomData(n = 30) {
 
 const sampleData = randomData(30);
 const sampleData100 = randomData(100);
+const sampleDataGaps = sampleData.map(x => x < -1 ? NaN : x);
 
 const Header = () =>
     <Sparklines data={sampleData} width={300} height={50}>
@@ -38,6 +39,11 @@ const Header = () =>
 
 const Simple = () =>
     <Sparklines data={sampleData}>
+        <SparklinesLine />
+    </Sparklines>
+
+const SimpleGaps = () =>
+    <Sparklines data={sampleDataGaps} gaps={true}>
         <SparklinesLine />
     </Sparklines>
 
@@ -295,6 +301,7 @@ const RealWorld9 = () =>
 const demos = {
     'headersparklines': Header,
     'simple': Simple,
+    'simpleGaps': SimpleGaps,
     'simpleCurve': SimpleCurve,
     'customizable1': Customizable1,
     'customizable2': Customizable2,

--- a/demo/index.html
+++ b/demo/index.html
@@ -114,6 +114,17 @@
             </xmp></pre>
         </div>
 
+        <h2>Simple w/Gaps</h2>
+
+        <div class="row">
+            <div id="simpleGaps"></div>
+            <pre class="prettyprint"><xmp>
+<Sparklines data={sampleDataGaps} gaps={true}>
+    <SparklinesLine />
+</Sparklines>
+            </xmp></pre>
+        </div>
+
         <h2>Simple Curve</h2>
 
         <div class="row">

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "enzyme": "^2.1.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
+    "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
+    "react-dom": "^0.14.7",
     "webpack": "^2.1.0-beta.4",
     "webpack-dev-server": "^2.0.0-beta"
   },

--- a/src/Sparklines.js
+++ b/src/Sparklines.js
@@ -17,7 +17,8 @@ class Sparklines extends React.Component {
         margin: React.PropTypes.number,
         style: React.PropTypes.object,
         min: React.PropTypes.number,
-        max: React.PropTypes.number
+        max: React.PropTypes.number,
+        gaps: React.PropTypes.bool
     };
 
     static defaultProps = {
@@ -39,15 +40,15 @@ class Sparklines extends React.Component {
             nextProps.max != this.props.max ||
             nextProps.limit != this.props.limit ||
             nextProps.data.length != this.props.data.length ||
-            nextProps.data.some((d, i) => d !== this.props.data[i]);
+            nextProps.data.some((d, i) => !Object.is(d, this.props.data[i]));
     }
 
     render() {
-        const { data, limit, width, height, margin, style, max, min } = this.props;
+        const { data, limit, width, height, margin, style, max, min, gaps } = this.props;
 
         if (data.length === 0) return null;
 
-        const points = DataProcessor.dataToPoints(data, limit, width, height, margin, max, min);
+        const points = DataProcessor.dataToPoints(data, limit, width, height, margin, max, min, gaps);
 
         return (
             <svg width={width} height={height} style={style} viewBox={`0 0 ${width} ${height}`}>

--- a/src/SparklinesLine.js
+++ b/src/SparklinesLine.js
@@ -1,4 +1,41 @@
 import React from 'react';
+import DataProcessor from './DataProcessor';
+
+function SparklinesLineSegment({points, width, height, margin, color, style}) {
+    if (!style)
+        style = {};
+
+    const linePoints = points
+        .map((p) => [p.x, p.y])
+        .reduce((a, b) => a.concat(b));
+    const closePolyPoints = [
+        points[points.length - 1].x, height - margin,
+        points[0].x, height - margin,
+        points[0].x, points[0].y
+    ];
+    const fillPoints = linePoints.concat(closePolyPoints);
+
+    const lineStyle = {
+        stroke: color || style.stroke || 'slategray',
+        strokeWidth: style.strokeWidth || '1',
+        strokeLinejoin: style.strokeLinejoin || 'round',
+        strokeLinecap: style.strokeLinecap || 'round',
+        fill: 'none'
+    };
+    const fillStyle = {
+        stroke: style.stroke || 'none',
+        strokeWidth: '0',
+        fillOpacity: style.fillOpacity || '.1',
+        fill: style.fill || color || 'slategray'
+    };
+
+    return (
+        <g>
+            <polyline points={fillPoints.join(' ')} style={fillStyle} />
+            <polyline points={linePoints.join(' ')} style={lineStyle} />
+        </g>
+    )
+}
 
 export default class SparklinesLine extends React.Component {
 
@@ -12,37 +49,23 @@ export default class SparklinesLine extends React.Component {
     };
 
     render() {
-        const { points, width, height, margin, color, style } = this.props;
-
-        const linePoints = points
-            .map((p) => [p.x, p.y])
-            .reduce((a, b) => a.concat(b));
-        const closePolyPoints = [
-            points[points.length - 1].x, height - margin,
-            margin, height - margin,
-            margin, points[0].y
-        ];
-        const fillPoints = linePoints.concat(closePolyPoints);
-
-        const lineStyle = {
-            stroke: color || style.stroke || 'slategray',
-            strokeWidth: style.strokeWidth || '1',
-            strokeLinejoin: style.strokeLinejoin || 'round',
-            strokeLinecap: style.strokeLinecap || 'round',
-            fill: 'none'
-        };
-        const fillStyle = {
-            stroke: style.stroke || 'none',
-            strokeWidth: '0',
-            fillOpacity: style.fillOpacity || '.1',
-            fill: style.fill || color || 'slategray'
-        };
-
+        const { points, height, margin, color, style } = this.props;
+        if (DataProcessor.pointsToSegments(points).length !== 1)
+            console.log(points);
         return (
             <g>
-                <polyline points={fillPoints.join(' ')} style={fillStyle} />
-                <polyline points={linePoints.join(' ')} style={lineStyle} />
+                {DataProcessor.pointsToSegments(points)
+                .filter(segment => !segment.isGap)
+                .map((segment, i) => (
+                    <SparklinesLineSegment
+                        key={i}
+                        points={segment.points}
+                        height={height}
+                        margin={margin}
+                        color={color}
+                        style={style} />)
+                )}
             </g>
-        )
+        );
     }
 }


### PR DESCRIPTION
I'm submitting this PR to gauge interest in the completed feature and get some feedback before I go ahead and implement it all.
The idea is to graphically represent data with in-band `null`s, `NaN`s or infinite values by drawing the valid (finite numeric) segments separately from one another.