### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
+before_install: npm install -g npm@3
 script: travis_retry npm test
 node_js:
 - '0.12'
+- '4'
+- '5'
 sudo: false

--- a/__tests__/Sparklines.js
+++ b/__tests__/Sparklines.js
@@ -3,10 +3,6 @@ import ReactDOM from 'react-dom';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import { Sparklines } from '../src/Sparklines';
-import jsdom from 'jsdom'
-
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
 
 describe('Sparklines', () => {
     it('does not throw without any parameters', () => {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "babel-runtime": "^6.6.1",
     "chai": "^3.5.0",
     "enzyme": "^2.1.0",
-    "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^0.14.7",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
     "webpack": "^2.1.0-beta.4",
     "webpack-dev-server": "^2.0.0-beta"
   },


### PR DESCRIPTION
There is a `peerDependencies` conflict between the versions of `babel-loader`, `webpack` and `webpack-dev-server` used here. I experimented a bit and eventually settled on using `npm@3` on Travis, which works nicely. I've now simplified this PR around the proposed solution.