### PR TITLE
Add `indexes` option

### DIFF
--- a/src/SparklinesSpots.js
+++ b/src/SparklinesSpots.js
@@ -17,36 +17,29 @@ export default class SparklinesSpots extends React.Component {
         }
     };
 
-    lastDirection(points) {
-
-        Math.sign = Math.sign || function(x) { return x > 0 ? 1 : -1; }
-
-        return points.length < 2
-            ? 0
-            : Math.sign(points[points.length - 2].y - points[points.length - 1].y);
-    }
-
     render() {
 
-        const { points, width, height, size, style, spotColors } = this.props;
-
-        const startSpot = <circle
-                            cx={points[0].x}
-                            cy={points[0].y}
-                            r={size}
-                            style={style} />
-
-        const endSpot = <circle
-                            cx={points[points.length - 1].x}
-                            cy={points[points.length - 1].y}
-                            r={size}
-                            style={style || { fill: spotColors[this.lastDirection(points)] }} />
+        const {points, size, style, spotColors, indexes = [0, points.length - 1]} = this.props;
 
         return (
-            <g>
-                {style && startSpot}
-                {endSpot}
-            </g>
+            <g>{
+                indexes.map(index => {
+                    if (!points[index]) {
+                        return;
+                    }
+
+                var direction = points[index -1] ?
+                    Math.sign(points[index -1].y - points[index].y) :
+                    0;
+
+                return <circle
+                    key={index}
+                    cx={points[index].x}
+                    cy={points[index].y}
+                    r={size}
+                    style={style || { fill: spotColors[direction] }} />;
+                })
+            }</g>
         )
     }
 }


### PR DESCRIPTION
Allow to specify `indexes` option in `SparklinesSpots`. This optional
parameter is an array of indexes that spots should appear at.

If parameter is not provided, spots are created at beginning and end by
default.