### PR TITLE
Fix/sparklinesbars

### DIFF
--- a/src/SparklinesBars.js
+++ b/src/SparklinesBars.js
@@ -17,17 +17,17 @@ export default class SparklinesBars extends React.Component {
 
         const { points, height, style, barWidth } = this.props;
         const strokeWidth = 1 * ((style && style.strokeWidth) || 0);
-        const width = barWidth || (points && points.length >= 2 ? Math.ceil(Math.max(0, points[1].x - points[0].x - strokeWidth)) : 0);
+        const width = barWidth || (points && points.length >= 2 ? Math.max(0, points[1].x - points[0].x - strokeWidth) : 0);
 
         return (
-            <g>
+            <g transform = "scale(1,-1)">
                 {points.map((p, i) =>
                     <rect
                         key={i}
-                        x={Math.ceil(p.x - strokeWidth * i)}
-                        y={Math.ceil(p.y)}
-                        width={Math.ceil(width)}
-                        height={Math.ceil(Math.max(0, height - p.y))}
+                        x={p.x - (width + strokeWidth)/2}
+                        y={-height}
+                        width={width}
+                        height={Math.max(0, height-p.y)}
                         style={style} />
                 )}
             </g>


### PR DESCRIPTION
This pull attempts to fix https://github.com/borisyankov/react-sparklines/issues/68.  `SparklinesBars` were not matching up at the bottom.  I transformed the `g` container for the bar with `transform="scale(1,-1)"` which allows us to start all bars from the same point which is `-height` and build up from there.  I also made sure that composed sparklines line up.
### before

![image](https://cloud.githubusercontent.com/assets/837910/19482979/5dd35a16-9518-11e6-94df-9bea4f17c18e.png)
### after

![image](https://cloud.githubusercontent.com/assets/837910/19483002/6a78b89c-9518-11e6-95d1-ac9aefd8efaa.png)
