### PR TITLE
add fillInvert style option for SparklinesLine fill

### DIFF
--- a/src/SparklinesLine.js
+++ b/src/SparklinesLine.js
@@ -15,13 +15,15 @@ export default class SparklinesLine extends React.Component {
   render() {
     const { data, points, width, height, margin, color, style, onMouseMove } = this.props;
 
+    const fillInvert = style.fillInvert ? style.fillInvert : false
+    
     const linePoints = points.map(p => [p.x, p.y]).reduce((a, b) => a.concat(b));
 
     const closePolyPoints = [
       points[points.length - 1].x,
-      height - margin,
+      fillInvert ? margin : height - margin,
       margin,
-      height - margin,
+      fillInvert ? margin : height - margin,
       margin,
       points[0].y,
     ];


### PR DESCRIPTION
This makes it possible to invert fill shading. I needed it for a project, so I added it. If you're not interested, feel free to close it. Looks like this:

![inverted_also](https://user-images.githubusercontent.com/3810489/39542927-acc3d876-4dfe-11e8-90e8-698889e10c05.png)
